### PR TITLE
If a user has a manager set, also set the manager field to their email address

### DIFF
--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -129,7 +129,7 @@ func (o *userResourceType) userTrait(ctx context.Context, user *jcapi1.Systemuse
 		profile.Fields["manager_id"] = structpb.NewStringValue(managerID)
 		manager, ok = o.managers[managerID]
 		if !ok {
-			m, _, err := client.SystemusersApi.SystemusersGet(ctx, managerID).Execute()
+			m, resp, err := client.SystemusersApi.SystemusersGet(ctx, managerID).Execute()
 			if err != nil {
 				l.Error(
 					"baton-jumpcloud: failed to fetch manager details",
@@ -138,6 +138,8 @@ func (o *userResourceType) userTrait(ctx context.Context, user *jcapi1.Systemuse
 					zap.String("manager_id", managerID),
 				)
 			}
+			defer resp.Body.Close()
+
 			manager = m
 			o.managers[user.GetManager()] = m
 		}


### PR DESCRIPTION
Previously we were only setting the `manager_id` field.