### PR TITLE
Opportunistically use system users to represent admins

### DIFF
--- a/.github/workflows/capabilities.yaml
+++ b/.github/workflows/capabilities.yaml
@@ -1,0 +1,34 @@
+name: Output connector capabilities
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  calculate-capabilities:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.RELENG_GITHUB_TOKEN }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Build
+        run: go build -o connector ./cmd/baton-jumpcloud
+
+      - name: Run and save output
+        run: ./connector capabilities > baton_capabilities.json
+
+      - name: Commit changes
+        uses: EndBug/add-and-commit@v9
+        with:
+          default_author: github_actions
+          message: 'Updating baton capabilities.'
+          add: 'baton_capabilities.json'

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -128,7 +128,7 @@ func (s *Jumpcloud) ResourceSyncers(ctx context.Context) []connectorbuilder.Reso
 		// NOTE: Jumpcloud has 'two' types of Users, "admin users" and... uh, "normal users".
 		// So, we put each in their own resource type.
 		// https://support.jumpcloud.com/support/s/article/getting-started-jumpcloud-admin-accounts-vs-user-accounts-2019-08-21-10-36-47
-		newUserBuilder(s.client1, s.client2),
+		newUserBuilder(s.client1, s.client2, s.ext),
 		newGroupBuilder(s.client1, s.client2),
 		newRoleBuilder(s.client1, s.ext),
 		newAppBuilder(s.client1, s.client2, s.ext),

--- a/pkg/connector/pagination.go
+++ b/pkg/connector/pagination.go
@@ -26,7 +26,7 @@ func unmarshalSkipToken(token *pagination.Token) (int32, *pagination.Bag, error)
 
 func marshalSkipToken(newObjects int, lastSkip int32, b *pagination.Bag) (string, error) {
 	if newObjects == 0 {
-		return "", nil
+		return nextToken(b, "")
 	}
 	nextSkip := int64(newObjects) + int64(lastSkip)
 	pageToken, err := nextToken(b, strconv.FormatInt(nextSkip, 10))


### PR DESCRIPTION
If the admin doesn't have a system user(by email), use their admin user identity instead.

Also add the capabilities workflow.