### PR TITLE
Add --base-url flag for connector testability

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -15,9 +15,10 @@ type Client struct {
 	extensionClient *uhttp.BaseHttpClient
 	apiKey          string
 	orgId           string
+	baseURL         string
 }
 
-func NewClient(ctx context.Context, apiKey string, orgId string) (*Client, error) {
+func NewClient(ctx context.Context, apiKey string, orgId string, baseURL string) (*Client, error) {
 	httpClient, err := uhttp.NewClient(ctx, uhttp.WithLogger(true, nil), uhttp.WithUserAgent("baton-jumpcloud/0.1.0"))
 	if err != nil {
 		return nil, err
@@ -30,6 +31,16 @@ func NewClient(ctx context.Context, apiKey string, orgId string) (*Client, error
 	cc2 := jcapi2.NewConfiguration()
 	cc2.HTTPClient = httpClient
 	cc2.UserAgent = "baton-jumpcloud/0.1.0"
+
+	// Override base URL if provided
+	if baseURL != "" {
+		cc1.Servers = jcapi1.ServerConfigurations{
+			{URL: baseURL + "/api"},
+		}
+		cc2.Servers = jcapi2.ServerConfigurations{
+			{URL: baseURL + "/api/v2"},
+		}
+	}
 
 	if orgId != "" {
 		// optional, only needed by API keys linked to multi-tenant admins
@@ -51,6 +62,7 @@ func NewClient(ctx context.Context, apiKey string, orgId string) (*Client, error
 		extensionClient: baseHttpClient,
 		apiKey:          apiKey,
 		orgId:           orgId,
+		baseURL:         baseURL,
 	}, nil
 }
 
@@ -90,10 +102,11 @@ func (jc *Client) ListDirectories(ctx context.Context, opts *Options) ([]jcapi2.
 
 func (jc *Client) GetUserByID(ctx context.Context, userID string) (*jcapi1.Userreturn, error) {
 	userGetRequest := &extension.UserGetRequest{
-		Client: jc.extensionClient,
-		ApiKey: jc.apiKey,
-		OrgId:  jc.orgId,
-		UserID: userID,
+		Client:  jc.extensionClient,
+		ApiKey:  jc.apiKey,
+		OrgId:   jc.orgId,
+		BaseURL: jc.baseURL,
+		UserID:  userID,
 	}
 
 	user, resp, err := userGetRequest.Execute(ctx)
@@ -131,9 +144,10 @@ func (jc *Client) ListAdminUsers(ctx context.Context, opts *Options) ([]jcapi1.U
 	page := opts.getPage()
 
 	userListRequest := &extension.UserListRequest{
-		Client: jc.extensionClient,
-		ApiKey: jc.apiKey,
-		OrgId:  jc.orgId,
+		Client:  jc.extensionClient,
+		ApiKey:  jc.apiKey,
+		OrgId:   jc.orgId,
+		BaseURL: jc.baseURL,
 	}
 
 	users, resp, err := userListRequest.Skip(page).Execute(ctx)

--- a/pkg/client/extension/extension.go
+++ b/pkg/client/extension/extension.go
@@ -10,11 +10,14 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/uhttp"
 )
 
+const defaultBaseURL = "https://console.jumpcloud.com"
+
 type UserListRequest struct {
-	Client *uhttp.BaseHttpClient
-	ApiKey string
-	OrgId  string
-	Page   int32
+	Client  *uhttp.BaseHttpClient
+	ApiKey  string
+	OrgId   string
+	BaseURL string
+	Page    int32
 }
 
 type listUserResponse struct {
@@ -44,9 +47,18 @@ func (ulr *UserListRequest) Execute(ctx context.Context) ([]jcapi1.Userreturn, *
 		qp.Set("skip", strconv.FormatInt(int64(ulr.Page), 10))
 	}
 
+	baseURL := ulr.BaseURL
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+	parsedBase, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	u := &url.URL{
-		Scheme:   "https",
-		Host:     "console.jumpcloud.com",
+		Scheme:   parsedBase.Scheme,
+		Host:     parsedBase.Host,
 		Path:     "/api/users",
 		RawQuery: qp.Encode(),
 	}
@@ -73,18 +85,28 @@ func (ulr *UserListRequest) Execute(ctx context.Context) ([]jcapi1.Userreturn, *
 }
 
 type UserGetRequest struct {
-	Client *uhttp.BaseHttpClient
-	ApiKey string
-	OrgId  string
-	UserID string
+	Client  *uhttp.BaseHttpClient
+	ApiKey  string
+	OrgId   string
+	BaseURL string
+	UserID  string
 }
 
 // Execute fetches an admin user by ID.
 // Uses uhttp.Do() with WithJSONResponse for automatic JSON unmarshaling and error handling.
 func (ugr *UserGetRequest) Execute(ctx context.Context) (*jcapi1.Userreturn, *http.Response, error) {
+	baseURL := ugr.BaseURL
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+	parsedBase, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	u := &url.URL{
-		Scheme: "https",
-		Host:   "console.jumpcloud.com",
+		Scheme: parsedBase.Scheme,
+		Host:   parsedBase.Host,
 		Path:   "/api/users/" + url.PathEscape(ugr.UserID),
 	}
 

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -6,6 +6,7 @@ import "reflect"
 type Jumpcloud struct {
 	ApiKey string `mapstructure:"api-key"`
 	OrgId string `mapstructure:"org-id"`
+	BaseUrl string `mapstructure:"base-url"`
 }
 
 func (c *Jumpcloud) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,11 +19,18 @@ var (
 		field.WithDescription("The Org ID for the JumpCloud account (optional, only needed by API keys linked to multi-tenant admins)."),
 	)
 
+	BaseURLField = field.StringField(
+		"base-url",
+		field.WithDisplayName("Base URL"),
+		field.WithDescription("Override the JumpCloud API base URL (for testing or enterprise deployments)."),
+	)
+
 	// ConfigurationFields defines the external configuration required for the
 	// connector to run.
 	ConfigurationFields = []field.SchemaField{
 		ApiKeyField,
 		OrgIdField,
+		BaseURLField,
 	}
 )
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,6 +24,7 @@ var (
 		field.WithDisplayName("Base URL"),
 		field.WithDescription("Override the JumpCloud API base URL (for testing or enterprise deployments)."),
 		field.WithHidden(true),
+		field.WithExportTarget(field.ExportTargetCLIOnly),
 	)
 
 	// ConfigurationFields defines the external configuration required for the

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,6 +23,7 @@ var (
 		"base-url",
 		field.WithDisplayName("Base URL"),
 		field.WithDescription("Override the JumpCloud API base URL (for testing or enterprise deployments)."),
+		field.WithHidden(true),
 	)
 
 	// ConfigurationFields defines the external configuration required for the

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -24,9 +24,9 @@ type Connector struct {
 type Option func(*Connector) error
 
 // WithAPIKey configures the connector with API key authentication.
-func WithAPIKey(ctx context.Context, apiKey string, orgId string) Option {
+func WithAPIKey(ctx context.Context, apiKey string, orgId string, baseURL string) Option {
 	return func(c *Connector) error {
-		client, err := client.NewClient(ctx, apiKey, orgId)
+		client, err := client.NewClient(ctx, apiKey, orgId, baseURL)
 		if err != nil {
 			return err
 		}
@@ -44,6 +44,7 @@ func NewLambdaConnector(ctx context.Context, jumpcloudCfg *cfg.Jumpcloud, cliOpt
 		ctx,
 		jumpcloudCfg.ApiKey,
 		jumpcloudCfg.OrgId,
+		jumpcloudCfg.BaseUrl,
 	)
 
 	cb, err := New(ctx, opts)


### PR DESCRIPTION
## Summary

Adds the `--base-url` CLI flag to enable overriding the default API endpoint for testing purposes.

## Changes

- Added `BaseURLField` to configuration
- Updated client/connector to accept and use the base URL override
- When `--base-url` is provided, it takes precedence over the default API URL

## Files Modified

```
pkg/client/client.go,pkg/client/extension/extension.go,pkg/config/conf.gen.go,pkg/config/config.go,pkg/connector/connector.go
```

## Testing

The connector can now be tested against mock servers:
```bash
baton-jumpcloud --base-url http://localhost:8080 [other-flags]
```

## Related

Part of the Connector Testability initiative.