### PR TITLE
docs: update Docker image registry from GHCR to ECR Public

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -190,7 +190,7 @@ spec:
     spec:
       containers:
       - name: baton-jumpcloud
-        image: ghcr.io/conductorone/baton-jumpcloud:latest
+        image: public.ecr.aws/conductorone/baton-jumpcloud:latest
         imagePullPolicy: IfNotPresent
         env:
         - name: BATON_HOST_ID
@@ -228,5 +228,3 @@ JumpCloud separates users and admin users, giving each a separate identity and l
 ### Why don't I see profile attributes listed for a JumpCloud admin user?
 
 An admin user in JumpCloud is intended only to manage the JumpCloud tenant, and not to be an identity that gains access to resources. Because of this design, admin users are not associated with the profile attributes, such as department or job title, that are associated with a non-admin user account.
-
-


### PR DESCRIPTION
## Summary

Connector images are now published exclusively to ECR Public (`public.ecr.aws/conductorone/`). This PR updates `docs/connector.mdx` accordingly.

**Changes made:**
- Updates Docker image reference from `ghcr.io/conductorone/` to `public.ecr.aws/conductorone/`
- Adds `### Resources` section (download center + GitHub repo links) if missing from the self-hosted setup instructions

_This PR was generated automatically._