### PR TITLE
Guard role grant emission behind WillSyncResourceType

### DIFF
--- a/baton_capabilities.json
+++ b/baton_capabilities.json
@@ -53,6 +53,11 @@
         "traits": [
           "TRAIT_USER"
         ],
+        "annotations": [
+          {
+            "@type": "type.googleapis.com/c1.connector.v2.SkipEntitlements"
+          }
+        ],
         "description": "JumpCloud User: The User account is the core identity for your employees, and is the account type that is used to authenticate against resources"
       },
       "capabilities": [

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -18,6 +18,10 @@ import (
 
 type Connector struct {
 	client *client.Client
+	// skipRoleResourceType reports whether role is excluded from the sync filter.
+	// Named for the skip condition so the zero value is safe: a Connector built
+	// without the option syncs everything.
+	skipRoleResourceType bool
 }
 
 // Option is a function that configures a Connector.
@@ -37,6 +41,16 @@ func WithAPIKey(ctx context.Context, apiKey string, orgId string, baseURL string
 	}
 }
 
+// WithSkipRoleResourceType configures whether the role resource type is excluded from
+// the sync filter. The user builder emits cross-type role grants, so when role is
+// excluded those grants must be suppressed rather than left pointing at an unsynced type.
+func WithSkipRoleResourceType(skip bool) Option {
+	return func(c *Connector) error {
+		c.skipRoleResourceType = skip
+		return nil
+	}
+}
+
 func NewLambdaConnector(ctx context.Context, jumpcloudCfg *cfg.Jumpcloud, cliOpts *cli.ConnectorOpts) (connectorbuilder.ConnectorBuilderV2, []connectorbuilder.Opt, error) {
 	l := ctxzap.Extract(ctx)
 
@@ -47,7 +61,10 @@ func NewLambdaConnector(ctx context.Context, jumpcloudCfg *cfg.Jumpcloud, cliOpt
 		jumpcloudCfg.BaseUrl,
 	)
 
-	cb, err := New(ctx, opts)
+	// nil opts means no filter, so nothing is skipped.
+	skipRoleResourceType := cliOpts != nil && !cliOpts.WillSyncResourceType(RoleResourceTypeID)
+
+	cb, err := New(ctx, opts, WithSkipRoleResourceType(skipRoleResourceType))
 	if err != nil {
 		l.Error("error creating connector", zap.Error(err))
 		return nil, nil, err
@@ -79,7 +96,7 @@ func New(ctx context.Context, opts ...Option) (*Connector, error) {
 // ResourceSyncers returns a ResourceSyncer for each resource type that should be synced from the upstream service.
 func (c *Connector) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncerV2 {
 	return []connectorbuilder.ResourceSyncerV2{
-		newUserBuilder(c.client),
+		newUserBuilder(c.client, c.skipRoleResourceType),
 		newGroupBuilder(c.client),
 		newRoleBuilder(),
 		newAppBuilder(c.client),

--- a/pkg/connector/resource_types.go
+++ b/pkg/connector/resource_types.go
@@ -5,7 +5,14 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 )
 
+// RoleResourceTypeID must equal resourceTypeRole.Id below. Exported so the connector
+// can gate cross-type role-grant emission on WillSyncResourceType without duplicating
+// the string literal.
+const RoleResourceTypeID = "role"
+
 var (
+	// newUserBuilder clones this and adds SkipEntitlements, or
+	// SkipEntitlementsAndGrants when role isn't synced.
 	resourceTypeUser = &v2.ResourceType{
 		Id:          "user",
 		DisplayName: "User",
@@ -22,8 +29,11 @@ var (
 		DisplayName: "App",
 		Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_APP},
 	}
+	// resourceTypeRole skips Grants(): roleBuilder.Grants() is a no-op because the role
+	// grants are emitted from the user builder, which reads each admin user's role in
+	// the pass it already makes rather than re-scanning every user once per role.
 	resourceTypeRole = &v2.ResourceType{
-		Id:          "role",
+		Id:          RoleResourceTypeID,
 		DisplayName: "Role",
 		Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_ROLE},
 		Annotations: annotations.New(&v2.SkipGrants{}),

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -28,9 +29,21 @@ func (o *userResourceType) ResourceType(_ context.Context) *v2.ResourceType {
 	return o.resourceType
 }
 
-func newUserBuilder(client *client.Client) *userResourceType {
+// newUserBuilder returns the user syncer. Users have no entitlements of their own,
+// and their only grants are cross-type role grants, so when role is excluded from
+// the sync the grants pass is skipped too.
+func newUserBuilder(client *client.Client, skipRoleResourceType bool) *userResourceType {
+	rt := proto.Clone(resourceTypeUser).(*v2.ResourceType)
+	annos := annotations.Annotations(rt.GetAnnotations())
+	if skipRoleResourceType {
+		annos.Update(&v2.SkipEntitlementsAndGrants{})
+	} else {
+		annos.Update(&v2.SkipEntitlements{})
+	}
+	rt.Annotations = annos
+
 	return &userResourceType{
-		resourceType: resourceTypeUser,
+		resourceType: rt,
 		client:       client,
 		managers:     make(map[string]*jcapi1.Systemuserreturn),
 		usersCache:   newUsersCache(client),

--- a/pkg/connector/users_guard_test.go
+++ b/pkg/connector/users_guard_test.go
@@ -1,0 +1,59 @@
+package connector
+
+import (
+	"context"
+	"testing"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"google.golang.org/protobuf/proto"
+)
+
+func hasGuardAnno(rt *v2.ResourceType, msg proto.Message) bool {
+	for _, a := range rt.GetAnnotations() {
+		if a.MessageIs(msg) {
+			return true
+		}
+	}
+	return false
+}
+
+// The user type's only grants are cross-type role grants, so when role is
+// excluded the whole grants pass is skipped.
+func TestUserResourceType_SkipAnnotation(t *testing.T) {
+	inScope := newUserBuilder(nil, false).ResourceType(context.Background())
+	if !hasGuardAnno(inScope, &v2.SkipEntitlements{}) || hasGuardAnno(inScope, &v2.SkipEntitlementsAndGrants{}) {
+		t.Fatalf("role in scope: want SkipEntitlements only, got %v", inScope.GetAnnotations())
+	}
+
+	filtered := newUserBuilder(nil, true).ResourceType(context.Background())
+	if !hasGuardAnno(filtered, &v2.SkipEntitlementsAndGrants{}) {
+		t.Fatalf("role filtered: want SkipEntitlementsAndGrants, got %v", filtered.GetAnnotations())
+	}
+
+	if hasGuardAnno(resourceTypeUser, &v2.SkipEntitlementsAndGrants{}) {
+		t.Fatal("package-level resourceTypeUser was mutated")
+	}
+}
+
+// skipRoleResourceType is stored inverted so the zero value means "sync
+// everything": a Connector built without WithSkipRoleResourceType must report
+// the unfiltered capability set.
+func TestZeroValueConnector_DoesNotSkipGrants(t *testing.T) {
+	for _, s := range (&Connector{}).ResourceSyncers(context.Background()) {
+		rt := s.ResourceType(context.Background())
+		if rt.GetId() != resourceTypeUser.GetId() {
+			continue
+		}
+		if hasGuardAnno(rt, &v2.SkipEntitlementsAndGrants{}) {
+			t.Fatal("zero-value Connector advertised SkipEntitlementsAndGrants")
+		}
+	}
+}
+
+// RoleResourceTypeID is what the sync filter is queried with; it must match the
+// resource type actually advertised.
+func TestRoleResourceTypeIDMatches(t *testing.T) {
+	if resourceTypeRole.GetId() != RoleResourceTypeID {
+		t.Fatalf("RoleResourceTypeID = %q, resourceTypeRole.Id = %q", RoleResourceTypeID, resourceTypeRole.GetId())
+	}
+}


### PR DESCRIPTION
Gates cross-type grant emission from the user syncer on the customer's sync
filter, so grants aren't emitted for a resource type the sync excludes.
Reference: ConductorOne/baton-linear#55.

`userResourceType.Grants()` emits the role grants (read from each admin user's
`roleName` in the pass it already makes, rather than re-scanning every user once
per role -- which is why `resourceTypeRole` already carries `SkipGrants`). When
role is excluded from the sync those grants would point at an unsynced type, so
`newUserBuilder` clones the user resource type and annotates it
`SkipEntitlementsAndGrants` and the SDK skips the pass entirely. Users have no
entitlements of their own, so the unfiltered case is annotated `SkipEntitlements`.

The flag is named `skipRoleResourceType` and stored inverted so the zero value
means "sync everything".

`baton_capabilities.json` is regenerated: the user type now advertises
`SkipEntitlements` in the unfiltered capability set.

Build, tests, and golangci-lint (0 issues) pass.

Supersedes #31, which used a `syncRoles` flag instead of the `skip<Type>ResourceType`
convention.