### PR TITLE
docs: clarify connector vs. SSO sign-in

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -6,6 +6,10 @@ og:description: "C1 provides identity governance for JumpCloud. Integrate your J
 sidebarTitle: "JumpCloud"
 ---
 
+<Note>
+This page covers the JumpCloud **connector**, which syncs and provisions access data for identity governance. It does not control how you sign in to C1. To set up signing in to C1 with your JumpCloud account, see [Authenticate with JumpCloud](/product/how-to/qs-set-up-c1#authenticate-with-jumpcloud).
+</Note>
+
 ## Capabilities
 
 | Resource | Sync | Provision |


### PR DESCRIPTION
## Summary
Adds a note to the top of the connector doc distinguishing this connector (identity governance sync/provisioning for C1) from signing in to C1 via this provider's SSO. Customers have been conflating the two.

## Context
The connector doc and the C1 tenant sign-in flow both involve the same identity provider, but they're unrelated setups (separate app registrations/OAuth clients in most cases). This note links to the specific SSO setup section for this provider so readers land in the right place.