### PR TITLE
Update deprecated ghcr.io image reference to public.ecr.aws

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ baton resources
 ## docker
 
 ```
-docker run --rm -v $(pwd):/out -e BATON_API_KEY=JumpCloudAPIKey ghcr.io/conductorone/baton-jumpcloud:latest -f "/out/sync.c1z"
+docker run --rm -v $(pwd):/out -e BATON_API_KEY=JumpCloudAPIKey public.ecr.aws/conductorone/baton-jumpcloud:latest -f "/out/sync.c1z"
 docker run --rm -v $(pwd):/out ghcr.io/conductorone/baton:latest -f "/out/sync.c1z" resources
 ```
 


### PR DESCRIPTION
## Summary
- README.md referenced this connector's image via `ghcr.io/conductorone/baton-jumpcloud:latest`; container images are now published to `public.ecr.aws/conductorone/baton-jumpcloud:latest` instead.
- Only this connector's own image reference was updated.
- Related audit: CXH-2418.

## Test plan
- [x] Verified `public.ecr.aws/conductorone/baton-jumpcloud:latest` resolves (manifest exists) before opening this PR.
- [x] Diff reviewed — only the image domain changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)